### PR TITLE
Use semver instead of regex for version validation

### DIFF
--- a/lib/appConfigBuilder.js
+++ b/lib/appConfigBuilder.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var semver = require('semver');
 var packageJson = require('./packageJson');
 
 function build(opts, loader) {
@@ -45,14 +46,13 @@ function validateId(id) {
 	}
 }
 
-var VERSION_REGEX = new RegExp('^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$');
 function validateVersion(version) {
 	if (!version) {
 		throw new Error( 'version was not specified and can\'t be found in package.json' );
 	}
 
-	if (!VERSION_REGEX.test(version)) {
-		throw new Error( 'version "' + version + '" is not in the form "#.#.#" or "#.#.#.#"');
+	if (!semver.valid(version)) {
+		throw new Error( 'version "' + version + '" is not a valid version number. See semver.org for more details.');
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "frau-local-appresolver": "^0.2.0",
     "frau-publisher": "^2.5.1",
     "q": "^1.4.1",
+    "semver": "^5.0.3",
     "streamifier": "^0.1.0",
     "vinyl-fs": "^1.0.0",
     "vinyl-source-stream": "^1.0.0",

--- a/test/appConfigBuilder.js
+++ b/test/appConfigBuilder.js
@@ -24,7 +24,7 @@ describe('appConfigBuilder', () => {
 
 			const spy = sinon.stub(require('../lib/packageJson'), 'read')
 				.returns({
-					version: '1.0.0.1',
+					version: '1.0.0-alpha.1',
 					description: 'It is a small world',
 					appId: 'urn:d2l:fra:id:some-id'
 				});
@@ -60,7 +60,7 @@ describe('appConfigBuilder', () => {
 
 			describe('defaults', () => {
 
-				const VERSION = '1.0.0.1',
+				const VERSION = '1.0.0-alpha.1',
 					DESCRIPTION = 'It is a small world',
 					ID = 'urn:d2l:fra:id:some-id';
 
@@ -107,7 +107,7 @@ describe('appConfigBuilder', () => {
 						'urn:d2l:fra:id:some-id', 
 						'urn:d2l:fra:id:some.id' 
 					],
-					version: [ '0.0.0.0', '1.0.0' ],
+					version: [ '0.0.0', '1.0.0-alpha.1' ],
 					description: [
 						'A simple description.', 
 						longString(1024) 
@@ -139,7 +139,7 @@ describe('appConfigBuilder', () => {
 
 				const VALUES = {
 					id: [ '....', '----', 'some--name', 'urn', 'urn:', 'urn:d2l:fra:id:some/id', 'urn:d2l:fra:id:some-id2' ],
-					version: [ '....', '1.0-something', '1.0.0.0.1', '1.0' ],
+					version: [ '....', '1.0-something', '1.0.0.1', '1.0', '1' ],
 					description: [ longString(1025) ],
 				};
 
@@ -203,7 +203,7 @@ describe('appConfigBuilder', () => {
 
 function createValidOpts() {
 	return {
-		version: '1.0.0.1',
+		version: '1.0.0-alpha.1',
 		description: 'It is a small world',
 		id: 'urn:d2l:fra:id:some-id',
 		loader: 'test'

--- a/test/htmlAppConfigBuilder .js
+++ b/test/htmlAppConfigBuilder .js
@@ -91,7 +91,7 @@ describe('htmlAppConfigBuilder', () => {
 
 function createValidOpts() {
 	return {
-		version: '1.0.0.1',
+		version: '1.0.0-alpha.1',
 		description: 'It is a small world',
 		id: 'urn:d2l:fra:id:some-id',
 		defaultResource: 'test'

--- a/test/iframeAppConfigBuilder.js
+++ b/test/iframeAppConfigBuilder.js
@@ -11,7 +11,7 @@ const expect = chai.expect;
 
 const TARGET = 'example.com/path/app.js';
 const OPTS = {
-	version: '1.0.0.1',
+	version: '1.0.0-alpha.1',
 	description: 'It is a small world',
 	id: 'urn:d2l:fra:id:some-id'
 };

--- a/test/umdAppConfigBuilder.js
+++ b/test/umdAppConfigBuilder.js
@@ -65,7 +65,7 @@ describe('umdAppConfigBuilder', () => {
 
 function createValidOpts() {
 	return {
-		version: '1.0.0.1',
+		version: '1.0.0-alpha.1',
 		description: 'It is a small world',
 		id: 'urn:d2l:fra:id:some-id',
 		showLoading: true


### PR DESCRIPTION
We are trying to publish a version of our FRA using semver’s pre-release tags. This would be a version like `1.2.3-pre.release.tag`. I notice in this repo we restrict versions to `#.#.#` or `#.#.#.#` but in `frau-publisher` we use `semver` to validate the version

This PR standardizes version validation across these two repos.

How do I publish a new npm package for this change? Do I bump the `package.json` version in the PR?

Also, should I add this change to [free-range-app-utils](https://github.com/Brightspace/free-range-app-utils)?

@dlockhart
@jmurray87