### PR TITLE
Update to latest frau-local-appresolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Brightspace/frau-appconfig-builder",
   "dependencies": {
     "chalk": "^1.0.0",
-    "frau-local-appresolver": "^0.2.0",
+    "frau-local-appresolver": "^1.0.0",
     "frau-publisher": "^2.5.1",
     "q": "^1.4.1",
     "semver": "^5.0.3",


### PR DESCRIPTION
The latest frau-local-appresolver prefers the FQDN over just the hostname. By using this version we will also get this value in our `endpoint` values when creating the appconfigs.